### PR TITLE
Separate keyword arguments and positional arguments

### DIFF
--- a/lib/corpshort/app.rb
+++ b/lib/corpshort/app.rb
@@ -274,7 +274,7 @@ module Corpshort
       rename = params[:new_name] && @link.name != params[:new_name]
       if rename
         new_name = link_name(params[:new_name])
-        @link = Link.new(name: new_name, url: @link.url)
+        @link = Link.new({name: new_name, url: @link.url})
         # Link.validate_name(new_name)
         # backend.rename_link(@link, new_name)
       end

--- a/lib/corpshort/app.rb
+++ b/lib/corpshort/app.rb
@@ -274,7 +274,7 @@ module Corpshort
       rename = params[:new_name] && @link.name != params[:new_name]
       if rename
         new_name = link_name(params[:new_name])
-        @link = Link.new({name: new_name, url: @link.url})
+        @link = Link.new(name: new_name, url: @link.url)
         # Link.validate_name(new_name)
         # backend.rename_link(@link, new_name)
       end

--- a/lib/corpshort/app.rb
+++ b/lib/corpshort/app.rb
@@ -164,7 +164,7 @@ module Corpshort
       name = link_name(name_given ? params[:linkname] : random_name)
       retries = 0
       begin
-        link = Link.new({name: name, url: params[:url]})
+        link = Link.new(name: name, url: params[:url])
         link.save!(backend, create_only: true)
       rescue Corpshort::Link::ValidationError
         session[:last_form] = {linkname: link.name, url: link.url}
@@ -324,7 +324,7 @@ module Corpshort
       end
 
       begin
-        link = Link.new({name: link_name, url: params[:url]})
+        link = Link.new(name: link_name, url: params[:url])
         link.save!(backend, create_only: true)
       rescue Corpshort::Link::ValidationError => e
         halt(400, {error: :validation_error, error_message: e.message}.to_json)

--- a/lib/corpshort/backends/dynamodb.rb
+++ b/lib/corpshort/backends/dynamodb.rb
@@ -48,7 +48,7 @@ module Corpshort
         ).items.first
 
         if item && !item.empty?
-          Link.new(item, backend: self)
+          Link.new(**item, backend: self)
         else
           nil
         end

--- a/lib/corpshort/backends/memory.rb
+++ b/lib/corpshort/backends/memory.rb
@@ -32,7 +32,7 @@ module Corpshort
       def get_link(name)
         data = @links[name]
         if data && !data.empty?
-          Link.new(data, backend: self)
+          Link.new(**data, backend: self)
         else
           nil
         end

--- a/lib/corpshort/backends/redis.rb
+++ b/lib/corpshort/backends/redis.rb
@@ -41,7 +41,7 @@ module Corpshort
       def get_link(name)
         data = redis.hgetall(link_key(name))
         if data && !data.empty?
-          Link.new(data, backend: self)
+          Link.new(**data, backend: self)
         else
           nil
         end

--- a/lib/corpshort/link.rb
+++ b/lib/corpshort/link.rb
@@ -12,13 +12,13 @@ module Corpshort
       raise ValidationError, "@name should satisfy #{NAME_REGEXP}" unless name.match?(NAME_REGEXP)
     end
 
-    def initialize(data, backend: nil)
+    def initialize(name:, url:, updated_at: nil, backend: nil)
       @backend = backend
 
-      @name = data[:name] || data['name']
-      @url = data[:url] || data['url']
+      @name = name
+      @url = url
       @parsed_url_point = nil
-      self.updated_at = data[:updated_at] || data['updated_at']
+      self.updated_at = updated_at
 
       validate!
     end

--- a/spec/backends/memory_spec.rb
+++ b/spec/backends/memory_spec.rb
@@ -3,7 +3,7 @@ require 'corpshort/link'
 
 RSpec.describe Corpshort::Backends::Memory do
   let(:backend) { described_class.new() }
-  let(:link) { Corpshort::Link.new({url: 'https://example.org', name: 'test'}) }
+  let(:link) { Corpshort::Link.new(url: 'https://example.org', name: 'test') }
 
   describe "#put_link" do
     it "creates link" do
@@ -48,18 +48,18 @@ RSpec.describe Corpshort::Backends::Memory do
 
   describe "#list_links_by_url" do
     it "returns a list of links for a URL" do
-      backend.put_link(Corpshort::Link.new({url: 'https://example.org', name: 'a'}))
-      backend.put_link(Corpshort::Link.new({url: 'https://example.org', name: 'b'}))
-      backend.put_link(Corpshort::Link.new({url: 'https://example.com', name: 'c'}))
+      backend.put_link(Corpshort::Link.new(url: 'https://example.org', name: 'a'))
+      backend.put_link(Corpshort::Link.new(url: 'https://example.org', name: 'b'))
+      backend.put_link(Corpshort::Link.new(url: 'https://example.com', name: 'c'))
       expect(backend.list_links_by_url('https://example.org').sort).to eq %w(a b)
     end
   end
 
   describe "#list_links" do
     it "returns a list of links" do
-      backend.put_link(Corpshort::Link.new({url: 'https://example.org', name: 'a'}))
-      backend.put_link(Corpshort::Link.new({url: 'https://example.org', name: 'b'}))
-      backend.put_link(Corpshort::Link.new({url: 'https://example.com', name: 'c'}))
+      backend.put_link(Corpshort::Link.new(url: 'https://example.org', name: 'a'))
+      backend.put_link(Corpshort::Link.new(url: 'https://example.org', name: 'b'))
+      backend.put_link(Corpshort::Link.new(url: 'https://example.com', name: 'c'))
 
       links, _token = backend.list_links()
       expect(links.sort).to eq %w(a b c)

--- a/spec/backends/memory_spec.rb
+++ b/spec/backends/memory_spec.rb
@@ -3,7 +3,7 @@ require 'corpshort/link'
 
 RSpec.describe Corpshort::Backends::Memory do
   let(:backend) { described_class.new() }
-  let(:link) { Corpshort::Link.new(url: 'https://example.org', name: 'test') }
+  let(:link) { Corpshort::Link.new({url: 'https://example.org', name: 'test'}) }
 
   describe "#put_link" do
     it "creates link" do
@@ -48,18 +48,18 @@ RSpec.describe Corpshort::Backends::Memory do
 
   describe "#list_links_by_url" do
     it "returns a list of links for a URL" do
-      backend.put_link(Corpshort::Link.new(url: 'https://example.org', name: 'a'))
-      backend.put_link(Corpshort::Link.new(url: 'https://example.org', name: 'b'))
-      backend.put_link(Corpshort::Link.new(url: 'https://example.com', name: 'c'))
+      backend.put_link(Corpshort::Link.new({url: 'https://example.org', name: 'a'}))
+      backend.put_link(Corpshort::Link.new({url: 'https://example.org', name: 'b'}))
+      backend.put_link(Corpshort::Link.new({url: 'https://example.com', name: 'c'}))
       expect(backend.list_links_by_url('https://example.org').sort).to eq %w(a b)
     end
   end
 
   describe "#list_links" do
     it "returns a list of links" do
-      backend.put_link(Corpshort::Link.new(url: 'https://example.org', name: 'a'))
-      backend.put_link(Corpshort::Link.new(url: 'https://example.org', name: 'b'))
-      backend.put_link(Corpshort::Link.new(url: 'https://example.com', name: 'c'))
+      backend.put_link(Corpshort::Link.new({url: 'https://example.org', name: 'a'}))
+      backend.put_link(Corpshort::Link.new({url: 'https://example.org', name: 'b'}))
+      backend.put_link(Corpshort::Link.new({url: 'https://example.com', name: 'c'}))
 
       links, _token = backend.list_links()
       expect(links.sort).to eq %w(a b c)


### PR DESCRIPTION
`Corpshort::Link#initialize` receives `data` argument as a positional argument: https://github.com/sorah/corpshort/blob/35e8d71f66851d311a6097c1755ed409ea50b573/lib/corpshort/link.rb#L15

So, for Ruby 3.0, I fixed some calls of `Corpshot::Link.new` which use keyword-argument syntax for `data` argument.