### PR TITLE
Fix double splats for Link.new

### DIFF
--- a/lib/corpshort/backends/dynamodb.rb
+++ b/lib/corpshort/backends/dynamodb.rb
@@ -48,7 +48,7 @@ module Corpshort
         ).items.first
 
         if item && !item.empty?
-          Link.new(**item, backend: self)
+          Link.new(name: item["name"], url: item["url"], updated_at: item["updated_at"], backend: self)
         else
           nil
         end

--- a/lib/corpshort/backends/redis.rb
+++ b/lib/corpshort/backends/redis.rb
@@ -41,7 +41,7 @@ module Corpshort
       def get_link(name)
         data = redis.hgetall(link_key(name))
         if data && !data.empty?
-          Link.new(**data, backend: self)
+          Link.new(name: data["name"], url: data["url"], updated_at: data["updated_at"], backend: self)
         else
           nil
         end


### PR DESCRIPTION
These double splats raise an error because keys of a result hash given by DynamoDB or Redis are String, not Symbol.
Also the hash of DynamoDB contains an extra key, which causes an error with double splats.

Follow-up: 13ab1f8c2008c3fa88fcc17434c6875e1e64fa14